### PR TITLE
Revert "Removes support for EOL OpenSSL versions < 3.0"

### DIFF
--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -49,6 +49,29 @@ static void sqlcipher_openssl_log_errors() {
     }
 }
 
+#if (defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
+static HMAC_CTX *HMAC_CTX_new(void)
+{
+  HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+  if (ctx != NULL) {
+    HMAC_CTX_init(ctx);
+  }
+  return ctx;
+}
+
+/* Per 1.1.0 (https://wiki.openssl.org/index.php/1.1_API_Changes)
+   HMAC_CTX_free should call HMAC_CTX_cleanup, then EVP_MD_CTX_Cleanup.
+   HMAC_CTX_cleanup internally calls EVP_MD_CTX_cleanup so these
+   calls are not needed. */
+static void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+  if (ctx != NULL) {
+    HMAC_CTX_cleanup(ctx);
+    OPENSSL_free(ctx);
+  }
+}
+#endif
+
 static int sqlcipher_openssl_add_random(void *ctx, const void *buffer, int length) {
 #ifndef SQLCIPHER_OPENSSL_NO_MUTEX_RAND
   sqlcipher_log(SQLCIPHER_LOG_TRACE, SQLCIPHER_LOG_MUTEX, "sqlcipher_openssl_add_random: entering SQLCIPHER_MUTEX_PROVIDER_RAND");
@@ -82,6 +105,15 @@ static int sqlcipher_openssl_activate(void *ctx) {
 
 #if (defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L)
   ERR_load_crypto_strings();
+#endif
+
+#ifdef SQLCIPHER_FIPS
+  if(!FIPS_mode()){
+    if(!(rc = FIPS_mode_set(1))){
+      sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_activate: FIPS_mode_set() returned %d", rc);
+      sqlcipher_openssl_log_errors();
+    }
+  }
 #endif
 
   openssl_init_count++; 
@@ -156,6 +188,76 @@ static int sqlcipher_openssl_hmac(
 ) {
   int rc = 0;
 
+#if (defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x30000000L)
+  unsigned int outlen;
+  HMAC_CTX* hctx = NULL;
+
+  if(in == NULL) goto error;
+
+  hctx = HMAC_CTX_new();
+  if(hctx == NULL) {
+    sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_CTX_new() failed");
+    sqlcipher_openssl_log_errors();
+    goto error;
+  }
+
+  switch(algorithm) {
+    case SQLCIPHER_HMAC_SHA1:
+      if(!(rc = HMAC_Init_ex(hctx, hmac_key, key_sz, EVP_sha1(), NULL))) {
+        sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_Init_ex() with key size %d and EVP_sha1() returned %d", key_sz, rc);
+        sqlcipher_openssl_log_errors();
+        goto error;
+      }
+      break;
+    case SQLCIPHER_HMAC_SHA256:
+      if(!(rc = HMAC_Init_ex(hctx, hmac_key, key_sz, EVP_sha256(), NULL))) {
+        sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_Init_ex() with key size %d and EVP_sha256() returned %d", key_sz, rc);
+        sqlcipher_openssl_log_errors();
+        goto error;
+      }
+      break;
+    case SQLCIPHER_HMAC_SHA512:
+      if(!(rc = HMAC_Init_ex(hctx, hmac_key, key_sz, EVP_sha512(), NULL))) {
+        sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_Init_ex() with key size %d and EVP_sha512() returned %d", key_sz, rc);
+        sqlcipher_openssl_log_errors();
+        goto error;
+      }
+      break;
+    default:
+      sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: invalid algorithm %d", algorithm);
+      goto error;
+  }
+
+  if(!(rc = HMAC_Update(hctx, in, in_sz))) {
+    sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_Update() on 1st input buffer of %d bytes using algorithm %d returned %d", in_sz, algorithm, rc);
+    sqlcipher_openssl_log_errors();
+    goto error;
+  }
+
+  if(in2 != NULL) {
+    if(!(rc = HMAC_Update(hctx, in2, in2_sz))) {
+      sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_Update() on 2nd input buffer of %d bytes using algorithm %d returned %d", in2_sz, algorithm, rc);
+      sqlcipher_openssl_log_errors();
+      goto error;
+    }
+  }
+
+  if(!(rc = HMAC_Final(hctx, out, &outlen))) {
+    sqlcipher_log(SQLCIPHER_LOG_ERROR, SQLCIPHER_LOG_PROVIDER, "sqlcipher_openssl_hmac: HMAC_Final() using algorithm %d returned %d", algorithm, rc);
+    sqlcipher_openssl_log_errors();
+    goto error;
+  }
+
+  rc = SQLITE_OK;
+  goto cleanup;
+
+error:
+  rc = SQLITE_ERROR;
+
+cleanup:
+  if(hctx) HMAC_CTX_free(hctx);
+
+#else
   size_t outlen;
   EVP_MAC *mac = NULL;
   EVP_MAC_CTX *hctx = NULL;
@@ -241,6 +343,8 @@ error:
 cleanup:
   if(hctx) EVP_MAC_CTX_free(hctx);
   if(mac) EVP_MAC_free(mac);
+
+#endif
 
   return rc;
 }
@@ -388,7 +492,11 @@ static int sqlcipher_openssl_ctx_free(void **ctx) {
 }
 
 static int sqlcipher_openssl_fips_status(void *ctx) {
+#ifdef SQLCIPHER_FIPS  
+  return FIPS_mode();
+#else
   return 0;
+#endif
 }
 
 int sqlcipher_openssl_setup(sqlcipher_provider *p) {


### PR DESCRIPTION
This reverts commit 801b81a8d0c42c13f66de89805c3bfa0d1d450aa.

Starting from v4.7.0, SQLCipher has removed the support for OpenSSL < 3, and we use LibreSSL which [only supports OpenSSL 1.1 API](https://github.com/libressl/portable?tab=readme-ov-file#compatibility-with-openssl). So to be able to use latest versions from SQLCipher, I've reverted the commit that removed 1.1 API  support as suggested in [this discussion](https://github.com/sqlcipher/sqlcipher/issues/548#issuecomment-2992368049) which [the revert] touches only _one file_, `crypto_openssl.c`. 

No changes made to that file in upstream except for a two-liners commit which is not affected by this revert ([see file history](https://github.com/sqlcipher/sqlcipher/commits/master/src/crypto_openssl.c)), so we should be fine to proceed with SQLCipher v4.9.0.

Commit Log: https://github.com/sqlcipher/sqlcipher/compare/v4.5.4...v4.9.0

_p.s. Our fork is now synced with upstream._

<details><summary>CHANGELOG</summary>
<p>

## [4.9.0] - (May 2025 - [4.9.0 changes])
- Updates baseline to upstream SQLite 3.46.2
- Removes use of static mutex in `sqlcipher_extra_shutdown()`
 
## [4.8.0] - (April 2025 - [4.8.0 changes])
- Fixes regression in `PRAGMA cipher_migrate` where an error would be thrown when migrating a current-version database
- Adds selective locking in critical sections of the library for shared cache connections (Note: use of shared cache is still strongly discouraged)
- Standardizes initial private heap size to 48KB to ensure mlock under constrained limits
- Removes changes to windows working set sizes
- Improvements to logging of memory stats and other cleanup

## [4.7.0] - (March 2025 - [4.7.0 changes])
- Updates baseline to upstream SQLite 3.49.1, including complete upstream SQLite refactoring of build system to use autosetup
- Significantly refactors and optimizes library initialization and cleanup
- Allocates majority of requisite memory at startup to improve memory locking on constrained platforms (i.e. Android and Windows) and reduce fragmentation
- Expands `sqlcipher_provider` interface to include `init` and `shutdown` functions
- Adds support for `.recover` shell command on corrupt databases with a full plaintext first page
- Performs fast random overwrite of freed memory segments for improved security
- Adds basic obfuscation of context key material for improved security
- Generates keyspecs dynamically on demand instead of storing them
- Expands keyspec/raw key format to accept key, HMAC key, and salt
- Improves error handling in `sqlcipher_export()` and `PRAGMA cipher_migrate`
- Allows setting custom compile-time default cryptographic provider via the `SQLCIPHER_CRYPTO_CUSTOM` macro
- Removes support for end-of-life OpenSSL versions older than 3.0
__BREAKING CHANGE__: `SELECT` statements (now also including schema independent queries like `SELECT 1`) cannot be executed on encrypt ed databases prior to setting the database key (behavior inherited from upstream SQLite)
- __BREAKING CHANGE__: Renames `configure` flag `--enable-tempstore=yes` to `--with-tempstore=yes` for alignment with SQLite (change required for upstream SQLite autosetup)
- __BREAKING CHANGE__: Renames default executable and library build outputs from `sqlcipher` and `libsqlcipher` to `sqlite3` and `libsqlite3` (for alignment with SQLite)
- __BREAKING CHANGE__: Removes `configure` flag `--with-crypto-lib` (replace with appropriate `-DSQLCIPHER_CRYPTO_*` CFLAG)
- __BREAKING CHANGE__: Requires defining `SQLITE_EXTRA_INIT=sqlcipher_extra_init` and `SQLITE_EXTRA_SHUTDOWN=sqlcipher_extra_shutdown` at compile time for optimized library initialization and cleanup
- __BREAKING CHANGE__: Enforces thread safe mode (i.e. `SQLITE_THREADSAFE` of 1 or 2) and temporary storage (i.e. `SQLITE_TEMP_STORE` of 2 or 3) settings at compile time

## [4.6.1] - (August 2024 - [4.6.1 changes])
- Updates baseline to upstream SQLite 3.46.1
- Significant refactor to merge `crypto.h`, `crypto.c`, and `crypto_impl.c` into a single `sqlcipher.c` source file for simplicity.
- Updates minimum working set size on windows to increase lockable pages
- Adds new `PRAGMA cipher_log_source` for filtering log output on higher verbosity levels
- Improves log output by including the log level and source prior to message
- Improves error logging in `PRAGMA cipher_migrate`
- Fixes issue where log level and target would be overwritten if set prior to initialization
- Corrects Podspec license element to use specific BSD 3 Clause
- Fixes default log output to console for macOS

## [4.6.0] - (May 2024 - [4.6.0 changes])
- Sets default log level to WARN
- Sends default log output to: logcat for Android; Console for iOS and macOS; and stderr for all other platforms
- General improvements to log level assignments, output, and sanitization
- Fixes Apple Privacy Manifest by removing empty NSPrivacyCollectedDataType from PrivacyInfo.xcprivacy
- Moves Swift support defines for podspec user_target_xcconfig so they only apply to the consuming project

## [4.5.7] - (April 2024 - [4.5.7 changes])
- Updates baseline to upstream SQLite 3.45.3
- Adds "device" logging and profile target using os_log for Apple (and logcat on Android)
- Fixes issues compiling with SQLITE_OMIT_LOG
- fixes malformed man page caused by old merge conflict
- Updates podspec for current Xcode versions, improved Swift support, and Privacy Manifest

## [4.5.6] - (January 2024 - [4.5.6 changes])
- Updates baseline to upstream SQLite 3.44.2
- Improve PRAGMA cipher_integrity check to report expected page size if invalid
- Implement PRAGMA page_size compatibility with PRAGMA cipher_page_size so both will operate properly on encrypted databases
- Updates LICENSE.md with SQLCipher license to avoid ambiguity and remove redundance

## [4.5.5] - (August 2023 - [4.5.5 changes])
- Updates baseline to upstream SQLite 3.42.0
- Do not allow key to be changed on a connection after it has been successfully used for an encryption or decryption operation to prevent accidental database corruption
- Raise an error if a rekey operation is attempted on an unencrypted database
- Raise an error when a key or rekey operation is passed an empty key
- Minor improvements to constant time functions
- Miscellaneous code and comment cleanup
</p>
</details> 
